### PR TITLE
Feature/title as argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ sudo cp target/release/leetr /usr/local/bin
 
 # Usage
 
-To use leetr, pass the URL of the LeetCode problem and the language of your choice (python/rust) to the tool. Note that the "description" part of the URL is mandatory as it is always present when opening the problem.
+To use leetr, pass the URL of the LeetCode problem or it's title and the language of your choice (python/rust) to the tool. 
 
 ## Arguments
-  - d, --dir <directory>  Create a directory with custom name for the problem, otherwise uses problem name
-  - l, --lang <language>  Programming language used to setup the project [default: rust]
-  - h, --help             Print help
+  - -d, --dir <directory>  Create a directory with custom name for the problem, otherwise uses problem name
+  - -l, --lang <language>  Programming language used to setup the project [default: rust]
+  - -h, --help             Print help
 
 This command generates a Python 3 project with the following structure:
 - A `two_sum/README.md` file describing the problem.
@@ -43,7 +43,7 @@ This command generates a Rust project with custom name and the following structu
 - A `my_project/README.md` file describing the problem.
 - A `my_project/main.rs` file containing the initial problem code
 ```sh
-leetr https://leetcode.com/problems/two-sum/description -l rust -d my_problem
+leetr two-sum -l rust -d my_problem
 ```
 
 # Supported languages

--- a/src/argument_parser.rs
+++ b/src/argument_parser.rs
@@ -41,10 +41,9 @@ pub fn get_title(input: String) -> Result<String, ProjectGeneratorError> {
                 ))
             })
     } else {
-        Ok(input.to_string())
+        Ok(input)
     }
 }
-
 #[cfg(test)]
 mod tests {
 
@@ -58,15 +57,18 @@ mod tests {
         assert_eq!(get_title(input).unwrap(), expected);
 
         let input = String::from("two-sum");
+
+        assert_eq!(get_title(input.clone()).unwrap(), input);
+
+        let input = String::from("https://leetcode.com/problems/two-sum");
         let expected = String::from("two-sum");
 
         assert_eq!(get_title(input).unwrap(), expected);
     }
 
     #[test]
-    #[should_panic]
     fn test_get_title_fails() {
-        let input = String::from("https://leetcode.com/problems");
-        get_title(input).unwrap();
+        let input = String::from("https://leetcode.com/problems/");
+        assert!(get_title(input).is_err());
     }
 }

--- a/src/argument_parser.rs
+++ b/src/argument_parser.rs
@@ -1,3 +1,4 @@
+use crate::errors::ProjectGeneratorError;
 use clap::{command, Arg, ArgMatches};
 
 pub fn parse_args() -> ArgMatches {
@@ -23,4 +24,49 @@ pub fn parse_args() -> ArgMatches {
         .arg(directory_arg)
         .arg(language_arg)
         .get_matches()
+}
+
+pub fn get_title(input: String) -> Result<String, ProjectGeneratorError> {
+    if input.contains("https://leetcode.com/problems") {
+        input
+            .trim_end_matches('/')
+            .rsplit("https://leetcode.com/problems")
+            .nth(0)
+            .and_then(|s| s.split('/').nth(1))
+            .map(|title| title.to_string())
+            .ok_or_else(|| {
+                ProjectGeneratorError::TitleExtractionError(format!(
+                    "Could not extract title from {}",
+                    input
+                ))
+            })
+    } else {
+        Ok(input.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::get_title;
+
+    #[test]
+    fn test_get_title() {
+        let input = String::from("https://leetcode.com/problems/two-sum/description/");
+        let expected = String::from("two-sum");
+
+        assert_eq!(get_title(input).unwrap(), expected);
+
+        let input = String::from("two-sum");
+        let expected = String::from("two-sum");
+
+        assert_eq!(get_title(input).unwrap(), expected);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_get_title_fails() {
+        let input = String::from("https://leetcode.com/problems");
+        get_title(input).unwrap();
+    }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -29,6 +29,9 @@ pub enum ProjectGeneratorError {
 
     #[error("ProjectGeneratorError [Command]: {0}")]
     Command(#[from] io::Error),
+
+    #[error("ProjectGeneratorError [Title Extraction]: {0}")]
+    TitleExtractionError(String),
 }
 
 #[derive(Error, Debug)]


### PR DESCRIPTION
Adds the possibility to pass problem title as argument

Old usage:
```sh
leetr https://leetcode.com/problems/two-sum/description/
```

Possible new usage:
```sh
leetr two-sum
```
