### PR TITLE
Merge parsing-examples into develop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "getrandom",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -127,6 +140,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -218,6 +237,61 @@ name = "core-foundation-sys"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+
+[[package]]
+name = "cssparser"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b3df4f93e5fbbe73ec01ec8d3f68bba73107993a5b1e7519273c32db9b0d5be"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa",
+ "phf 0.10.1",
+ "smallvec",
+]
+
+[[package]]
+name = "cssparser-macros"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
+dependencies = [
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
+name = "derive_more"
+version = "0.99.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
+name = "dtoa"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653"
+
+[[package]]
+name = "dtoa-short"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
+dependencies = [
+ "dtoa",
+]
+
+[[package]]
+name = "ego-tree"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a68a4904193147e0a8dec3314640e6db742afd5f6e634f428a6af230d9b3591"
 
 [[package]]
 name = "encoding_rs"
@@ -364,6 +438,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "getopts"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -423,7 +515,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be92446e11d68f5d71367d571c229d09ced1f24ab6d08ea0bff329d5f6c0b2a3"
 dependencies = [
- "html5ever",
+ "html5ever 0.26.0",
  "jni",
  "lazy_static",
  "markup5ever_rcdom",
@@ -439,10 +531,24 @@ checksum = "bea68cab48b8459f17cf1c944c67ddc572d272d9f2b274140f223ecb1da4a3b7"
 dependencies = [
  "log",
  "mac",
- "markup5ever",
+ "markup5ever 0.11.0",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13771afe0e6e846f1e67d038d4cb29998a6779f93c809212e4e9c32efd244d4"
+dependencies = [
+ "log",
+ "mac",
+ "markup5ever 0.12.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -630,6 +736,7 @@ dependencies = [
  "html2md",
  "log",
  "reqwest",
+ "scraper",
  "serde",
  "serde_json",
  "strum",
@@ -680,8 +787,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2629bb1404f3d34c2e921f21fd34ba00b206124c81f65c50b43b6aaefeb016"
 dependencies = [
  "log",
- "phf",
- "phf_codegen",
+ "phf 0.10.1",
+ "phf_codegen 0.10.0",
+ "string_cache",
+ "string_cache_codegen",
+ "tendril",
+]
+
+[[package]]
+name = "markup5ever"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16ce3abbeba692c8b8441d036ef91aea6df8da2c6b6e21c7e14d3c18e526be45"
+dependencies = [
+ "log",
+ "phf 0.11.2",
+ "phf_codegen 0.11.2",
  "string_cache",
  "string_cache_codegen",
  "tendril",
@@ -693,8 +814,8 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9521dd6750f8e80ee6c53d65e2e4656d7de37064f3a7a5d2d11d05df93839c2"
 dependencies = [
- "html5ever",
- "markup5ever",
+ "html5ever 0.26.0",
+ "markup5ever 0.11.0",
  "tendril",
  "xml5ever",
 ]
@@ -858,7 +979,18 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
 dependencies = [
- "phf_shared",
+ "phf_macros",
+ "phf_shared 0.10.0",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
+dependencies = [
+ "phf_shared 0.11.2",
 ]
 
 [[package]]
@@ -867,8 +999,18 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb1c3a8bc4dd4e5cfce29b44ffc14bedd2ee294559a294e2a4d4c9e9a6a13cd"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.10.0",
+ "phf_shared 0.10.0",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8d39688d359e6b34654d328e262234662d16cc0f60ec8dcbe5e718709342a5a"
+dependencies = [
+ "phf_generator 0.11.2",
+ "phf_shared 0.11.2",
 ]
 
 [[package]]
@@ -877,8 +1019,32 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.10.0",
  "rand",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
+dependencies = [
+ "phf_shared 0.11.2",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58fdf3184dd560f160dd73922bea2d5cd6e8f064bf4b13110abd81b03697b4e0"
+dependencies = [
+ "phf_generator 0.10.0",
+ "phf_shared 0.10.0",
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -886,6 +1052,15 @@ name = "phf_shared"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
 dependencies = [
  "siphasher",
 ]
@@ -939,6 +1114,12 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.20+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
@@ -1141,6 +1322,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scraper"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "761fb705fdf625482d2ed91d3f0559dcfeab2798fe2771c69560a774865d0802"
+dependencies = [
+ "ahash",
+ "cssparser",
+ "ego-tree",
+ "getopts",
+ "html5ever 0.27.0",
+ "once_cell",
+ "selectors",
+ "tendril",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1161,6 +1358,25 @@ checksum = "317936bbbd05227752583946b9e66d7ce3b489f84e11a94a510b4437fef407d7"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "selectors"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eb30575f3638fc8f6815f448d50cb1a2e255b0897985c8c59f4d37b72a07b06"
+dependencies = [
+ "bitflags 2.5.0",
+ "cssparser",
+ "derive_more",
+ "fxhash",
+ "log",
+ "new_debug_unreachable",
+ "phf 0.10.1",
+ "phf_codegen 0.10.0",
+ "precomputed-hash",
+ "servo_arc",
+ "smallvec",
 ]
 
 [[package]]
@@ -1216,6 +1432,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "servo_arc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d036d71a959e00c77a63538b90a6c2390969f9772b096ea837205c6bd0491a44"
+dependencies = [
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1247,6 +1472,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "string_cache"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1255,7 +1486,7 @@ dependencies = [
  "new_debug_unreachable",
  "once_cell",
  "parking_lot",
- "phf_shared",
+ "phf_shared 0.10.0",
  "precomputed-hash",
  "serde",
 ]
@@ -1266,8 +1497,8 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bb30289b722be4ff74a408c3cc27edeaad656e06cb1fe8fa9231fa59c728988"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.10.0",
+ "phf_shared 0.10.0",
  "proc-macro2",
  "quote",
 ]
@@ -1557,6 +1788,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-width"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
+
+[[package]]
 name = "url"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1584,6 +1821,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "walkdir"
@@ -1861,5 +2104,25 @@ checksum = "4034e1d05af98b51ad7214527730626f019682d797ba38b51689212118d8e650"
 dependencies = [
  "log",
  "mac",
- "markup5ever",
+ "markup5ever 0.11.0",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,5 @@ strum_macros = "0.26"
 thiserror = "1.0.60"
 tl = "0.7.8"
 toml = "0.8.12"
+scraper = "0.19.1"
+

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,6 +1,7 @@
+use std::io;
+
 use reqwest::Error as ReqwestError;
 use serde_json::Error as SerdeError;
-use std::io;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -37,4 +38,13 @@ pub enum ProjectGeneratorError {
 
     #[error("🚫 Language '{0}' is not supported yet, please select one from [{1}].")]
     LanguageSupportIsNotAvailable(String, String),
+}
+
+#[derive(Error, Debug)]
+pub enum ExampleParsingError {
+    #[error("Could not find the first example to parse")]
+    CouldNotFindExample,
+
+    #[error("Could not find Constraints section to stop the parsing")]
+    CouldNotFindConstraints,
 }

--- a/src/example_parser.rs
+++ b/src/example_parser.rs
@@ -1,0 +1,270 @@
+use std::collections::HashMap;
+
+use scraper::{Html, Selector};
+
+use errors::ExampleParsingError;
+
+use crate::errors;
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum InputType {
+    Int(i32),
+    VecInt(Vec<i32>),
+    String(String),
+    VecString(Vec<String>),
+    // TODO: Well, run the big test and fix 1 by 1
+}
+
+
+#[derive(Debug)]
+pub struct Example {
+    pub inputs: HashMap<String, InputType>,
+    pub output: InputType,
+}
+#[derive(Debug)]
+pub struct ExampleParser {
+    // The LeetCode Markdown text
+    description: String,
+    pub examples: Vec<Example>,
+}
+
+impl ExampleParser {
+    fn html_to_text(html_content: &str) -> String {
+        let document = Html::parse_document(html_content);
+        // TODO fix this unwrap
+        let selector = Selector::parse("body").unwrap();
+        let mut text_content = String::new();
+
+        for element in document.select(&selector) {
+            text_content.push_str(&element.text().collect::<Vec<_>>().join(" "));
+        }
+
+        text_content
+    }
+    pub fn new(html: &str) -> Self {
+        let description = Self::html_to_text(html);
+        ExampleParser {
+            description,
+            examples: Vec::new(),
+        }
+    }
+
+    pub fn parse(&mut self) -> Result<(), ExampleParsingError> {
+        let example_sections = self.get_example_sections()?;
+        let example_sections = self.split_examples(example_sections);
+
+        let examples = example_sections.iter().filter_map(|example| self.parse_example(example)).collect::<Vec<Example>>();
+
+        self.examples = examples;
+        Ok(())
+    }
+
+    fn get_example_sections(&self) -> Result<&str, ExampleParsingError> {
+        let start = self.description.find("Example 1:").ok_or(ExampleParsingError::CouldNotFindExample)?;
+        let end = self.description.rfind("Constraints:").ok_or(ExampleParsingError::CouldNotFindConstraints)?;
+
+        Ok(&self.description[start..end])
+    }
+
+    fn split_examples(&self, examples_section: &str) -> Vec<String> {
+        examples_section.split("Example ").filter_map(|s| {
+            let cleaned: String = s.replace("\n", " ").split_whitespace().collect::<Vec<&str>>().join(" ");
+            if cleaned.is_empty() {
+                None
+            } else {
+                Some(format!("Example {}", cleaned))
+            }
+        }).collect()
+    }
+
+    fn parse_example(&self, example: &str) -> Option<Example> {
+        let input_start = example.find("Input:")?;
+        let output_start = example.find("Output")?;
+        let remainder = &example[output_start + 7..];
+        let end_of_line = remainder.find(" Explanation").unwrap_or(remainder.len());
+
+
+        // Adding the lengths of the actual words of Input:/Output:
+        let inputs_str = example[input_start + 6..output_start].trim();
+        let outputs_str = remainder[..end_of_line].trim();
+
+        let inputs = self.parse_inputs(inputs_str);
+        let output = self.parse_output(outputs_str);
+        Some(Example { inputs, output })
+    }
+
+    fn parse_inputs(&self, input_str: &str) -> HashMap<String, InputType> {
+        let mut inputs = HashMap::new();
+
+        for input in input_str.split(',') {
+            if let Some((key, value)) = input.split_once('=') {
+                let parsed_value = Self::parse_value(value.trim());
+                inputs.insert(key.trim().to_string(), parsed_value);
+            }
+        }
+        inputs
+    }
+
+    fn parse_output(&self, output_str: &str) -> InputType {
+        Self::parse_value(output_str)
+    }
+    fn parse_value(value: &str) -> InputType {
+        if value.starts_with('[') && value.ends_with(']') {
+            let trimmed = &value[1..value.len() - 1];
+            if trimmed.contains('"') {
+                let vec_str: Vec<String> = trimmed.split(',').map(|s| s.trim().replace('"', "")).collect();
+                InputType::VecString(vec_str)
+            } else {
+                let vec_int: Vec<i32> = trimmed.split(',').filter_map(|s| s.trim().parse().ok()).collect();
+                InputType::VecInt(vec_int)
+            }
+        } else if value.starts_with('"') && value.ends_with('"') {
+            InputType::String(value.trim_matches('"').to_string())
+        } else {
+            match value.parse::<i32>() {
+                Ok(int_val) => InputType::Int(int_val),
+                Err(_) => InputType::String(value.to_string()),  // Default to String if parsing fails
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const HTML_CONTENT: &str = r#"
+        <p>Given a string <code>s</code>, find the length of the <strong>longest</strong>
+        <span data-keyword="substring-nonempty"><strong>substring</strong></span> without repeating characters.</p>
+
+        <p>&nbsp;</p>
+        <p><strong class="example">Example 1:</strong></p>
+
+        <pre>
+        <strong>Input:</strong> s = "abcabcbb"
+        <strong>Output:</strong> 3
+        <strong>Explanation:</strong> The answer is "abc", with the length of 3.
+        </pre>
+
+        <p><strong class="example">Example 2:</strong></p>
+
+        <pre>
+        <strong>Input:</strong> s = "bbbbb"
+        <strong>Output:</strong> 1
+        <strong>Explanation:</strong> The answer is "b", with the length of 1.
+        </pre>
+
+        <p><strong class="example">Example 3:</strong></p>
+
+        <pre>
+        <strong>Input:</strong> s = "pwwkew"
+        <strong>Output:</strong> 3
+        <strong>Explanation:</strong> The answer is "wke", with the length of 3.
+        Notice that the answer must be a substring, "pwke" is a subsequence and not a substring.
+        </pre>
+
+        <p>&nbsp;</p>
+        <p><strong>Constraints:</strong></p>
+
+        <ul>
+            <li><code>0 &lt;= s.length &lt;= 5 * 10<sup>4</sup></code></li>
+            <li><code>s</code> consists of English letters, digits, symbols and spaces.</li>
+        </ul>
+    "#;
+
+    const HTML_CONTENT_WITH_VEC: &str = r#"
+        <p>Given an array of integers <code>nums</code>&nbsp;and an integer <code>target</code>, return <em>indices of the two numbers such that they add up to <code>target</code></em>.</p>
+
+        <p>You may assume that each input would have <strong><em>exactly</em> one solution</strong>, and you may not use the <em>same</em> element twice.</p>
+
+        <p>You can return the answer in any order.</p>
+
+        <p>&nbsp;</p>
+        <p><strong class="example">Example 1:</strong></p>
+
+        <pre>
+        <strong>Input:</strong> nums = [2,7,11,15], target = 9
+        <strong>Output:</strong> [0,1]
+        <strong>Explanation:</strong> Because nums[0] + nums[1] == 9, we return [0, 1].
+        </pre>
+
+        <p><strong class="example">Example 2:</strong></p>
+
+        <pre>
+        <strong>Input:</strong> nums = [3,2,4], target = 6
+        <strong>Output:</strong> [1,2]
+        </pre>
+
+        <p><strong class="example">Example 3:</strong></p>
+
+        <pre>
+        <strong>Input:</strong> nums = [3,3], target = 6
+        <strong>Output:</strong> [0,1]
+        </pre>
+
+        <p>&nbsp;</p>
+        <p><strong>Constraints:</strong></p>
+
+        <ul>
+            <li><code>2 &lt;= nums.length &lt;= 10<sup>4</sup></code></li>
+            <li><code>-10<sup>9</sup> &lt;= nums[i] &lt;= 10<sup>9</sup></code></li>
+            <li><code>-10<sup>9</sup> &lt;= target &lt;= 10<sup>9</sup></code></li>
+            <li><strong>Only one valid answer exists.</strong></li>
+        </ul>
+
+        <p>&nbsp;</p>
+        <strong>Follow-up:&nbsp;</strong>Can you come up with an algorithm that is less than <code>O(n<sup>2</sup>)</code> time complexity?
+    "#;
+
+    #[test]
+    fn test_get_example_sections() {
+        let parser = ExampleParser::new(HTML_CONTENT);
+        let section = parser.get_example_sections().unwrap();
+        assert!(section.contains("Example 1:"));
+        assert!(section.contains("Example 2:"));
+        assert!(section.contains("Example 3:"));
+
+        let parser_with_vec = ExampleParser::new(HTML_CONTENT_WITH_VEC);
+        let section_with_vec = parser_with_vec.get_example_sections().unwrap();
+        assert!(section_with_vec.contains("Example 1:"));
+        assert!(section_with_vec.contains("Example 2:"));
+        assert!(section_with_vec.contains("Example 3:"));
+    }
+
+    #[test]
+    fn test_parse_example() {
+        let parser = ExampleParser::new(HTML_CONTENT);
+        let section = parser.get_example_sections().unwrap();
+        let examples = parser.split_examples(section);
+        assert_eq!(examples.len(), 3);
+        assert!(examples[0].contains("Input: s = \"abcabcbb\""));
+        assert!(examples[0].contains("Output: 3"));
+
+        let parser_with_vec = ExampleParser::new(HTML_CONTENT_WITH_VEC);
+        let section_with_vec = parser_with_vec.get_example_sections().unwrap();
+        let examples_with_vec = parser_with_vec.split_examples(section_with_vec);
+        assert_eq!(examples_with_vec.len(), 3);
+        assert!(examples_with_vec[0].contains("Input: nums = [2,7,11,15], target = 9"));
+        assert!(examples_with_vec[0].contains("Output: [0,1]"));
+    }
+
+    #[test]
+    fn test_parse_output() {
+        let mut parser = ExampleParser::new(HTML_CONTENT);
+        parser.parse().unwrap();
+        let output = &parser.examples[0].output;
+        assert_eq!(output, &InputType::Int(3));
+
+        let mut parser_with_vec = ExampleParser::new(HTML_CONTENT_WITH_VEC);
+        parser_with_vec.parse().unwrap();
+        let output_with_vec = &parser_with_vec.examples[0].output;
+        assert_eq!(output_with_vec, &InputType::VecInt(vec![0, 1]));
+    }
+
+    #[test]
+    fn test_empty() {
+        let parser = ExampleParser::new("");
+        let section = parser.get_example_sections();
+        assert!(section.is_err());
+    }
+}

--- a/src/example_parser.rs
+++ b/src/example_parser.rs
@@ -32,7 +32,6 @@ pub struct ExampleParser {
     pub examples: Vec<Example>,
 }
 
-
 #[allow(dead_code)]
 impl ExampleParser {
     fn html_to_text(html_content: &str) -> String {
@@ -117,7 +116,7 @@ impl ExampleParser {
     }
 
     fn parse_value(value: &str) -> InputType {
-        if value.starts_with('"') && value.ends_with(']') {
+        if value.starts_with('[') && value.ends_with(']') {
             let trimmed = &value[1..value.len() - 1];
             if trimmed.contains('"') {
                 let vec_str: Vec<String> = trimmed.split(',').map(|s| s.trim().replace('"', "")).collect();

--- a/src/example_parser.rs
+++ b/src/example_parser.rs
@@ -6,6 +6,7 @@ use errors::ExampleParsingError;
 
 use crate::errors;
 
+#[allow(dead_code)]
 #[derive(Debug, Eq, PartialEq)]
 pub enum InputType {
     Int(i32),
@@ -16,11 +17,14 @@ pub enum InputType {
 }
 
 
+#[allow(dead_code)]
 #[derive(Debug)]
 pub struct Example {
     pub inputs: HashMap<String, InputType>,
     pub output: InputType,
 }
+
+#[allow(dead_code)]
 #[derive(Debug)]
 pub struct ExampleParser {
     // The LeetCode Markdown text
@@ -28,6 +32,8 @@ pub struct ExampleParser {
     pub examples: Vec<Example>,
 }
 
+
+#[allow(dead_code)]
 impl ExampleParser {
     fn html_to_text(html_content: &str) -> String {
         let document = Html::parse_document(html_content);
@@ -68,7 +74,7 @@ impl ExampleParser {
 
     fn split_examples(&self, examples_section: &str) -> Vec<String> {
         examples_section.split("Example ").filter_map(|s| {
-            let cleaned: String = s.replace("\n", " ").split_whitespace().collect::<Vec<&str>>().join(" ");
+            let cleaned: String = s.replace('\n', " ").split_whitespace().collect::<Vec<&str>>().join(" ");
             if cleaned.is_empty() {
                 None
             } else {
@@ -111,17 +117,17 @@ impl ExampleParser {
     }
 
     fn parse_value(value: &str) -> InputType {
-        if value.starts_with("[") && value.ends_with("]") {
+        if value.starts_with('"') && value.ends_with(']') {
             let trimmed = &value[1..value.len() - 1];
-            if trimmed.contains("\"") {
-                let vec_str: Vec<String> = trimmed.split(",").map(|s| s.trim().replace("\"", "")).collect();
+            if trimmed.contains('"') {
+                let vec_str: Vec<String> = trimmed.split(',').map(|s| s.trim().replace('"', "")).collect();
                 InputType::VecString(vec_str)
             } else {
-                let vec_int: Vec<i32> = trimmed.split(",").filter_map(|s| s.trim().parse().ok()).collect();
+                let vec_int: Vec<i32> = trimmed.split(',').filter_map(|s| s.trim().parse().ok()).collect();
                 InputType::VecInt(vec_int)
             }
-        } else if value.starts_with("\"") && value.ends_with("\"") {
-            InputType::String(value.trim_matches('\"').to_string())
+        } else if value.starts_with('"') && value.ends_with('"') {
+            InputType::String(value.trim_matches('"').to_string())
         } else {
             match value.parse::<i32>() {
                 Ok(int_val) => InputType::Int(int_val),

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use std::process;
 use log::error;
 
 mod argument_parser;
+mod example_parser;
 mod errors;
 mod html;
 mod logger;


### PR DESCRIPTION
This MR will add the functionality to parse Examples from LeetCode's problem description. It will return a Struct `Example` containing a HashMap of `<String, InputType>` that correcponds to example variable name and it's value and infered data type and a field output that holds the expected value for the test, with infered data type.